### PR TITLE
SSTable and SSTableIndex deserialization

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include "memtable_queue.h"
 #include "serializer.h"
 #include "sstable.h"
+#include "table.h"
 #include "value.h"
 
 using namespace std;
@@ -49,28 +50,40 @@ int main() {
     //        Serializable<pair<int, vector<pair<vector<pair<Key, Value>>,
     //        Key>>>>, "Pair<int, vector<int>>");
 
-    //    db_config::MEMTABLE_APPROXIMATE_MAX_SIZE_IN_BYTES = 100;
-    //    MemTableQueue mq;
-    //    vector<future<SSTableIndex>> futures;
-    //    for (int i = 0; i < 6; i++) {
-    //        auto tmp = mq.set(to_string(i), "Hello World!");
-    //        if (tmp.has_value()) {
-    //            futures.emplace_back(move(tmp.value()));
-    //        }
-    //    }
-    //    int cnt = 0;
-    //    for (auto& ft : futures) {
-    //        while (ft.wait_for(chrono::seconds(0)) != future_status::ready) {
-    //        }
-    //        log::debug("Future ", cnt, " ready: ", ft.get());
-    //        cnt += 1;
-    //    }
-
+    db_config::MEMTABLE_APPROXIMATE_MAX_SIZE_IN_BYTES = 100;
     db_config::SSTABLE_INDEX_BLOCK_SIZE_IN_BYTES = 50;
-    SSTable sst;
-    SSTableIndex ssti;
-    sst.loadFromDisk("project_db_0_22590.sst", &ssti);
-    log::debug(ssti);
+    MemTableQueue mq;
+    vector<future<SSTableIndex>> futures;
+    for (int i = 0; i < 6; i++) {
+        auto tmp =
+            mq.set(to_string(2 * i), "! Hello World " + to_string(2 * i));
+        if (tmp.has_value()) {
+            futures.emplace_back(move(tmp.value()));
+        }
+    }
+    int cnt = 0;
+    for (auto& ft : futures) {
+        while (ft.wait_for(chrono::seconds(0)) != future_status::ready) {
+        }
+        auto index = ft.get();
+        log::debug("Future ", cnt, " ready: ", index);
+        cnt += 1;
+        Key key("6");
+        auto tmp = index.seek(key);
+        if (!tmp.has_value()) {
+            log::debug(key, " not found!");
+        } else {
+            log::debug(tmp.value());
+        }
+        //        auto tmpTable =
+        //        SerializationWrapper<Table::mapped_type>().deserialize()
+    }
+
+    //    db_config::SSTABLE_INDEX_BLOCK_SIZE_IN_BYTES = 0;
+    //    SSTable sst;
+    //    SSTableIndex ssti;
+    //    sst.loadFromDisk("project_db_0_22590.sst", &ssti);
+    //    log::debug(ssti);
     return 0;
 }
 

--- a/utils/serializer.h
+++ b/utils/serializer.h
@@ -246,6 +246,21 @@ class SerializationWrapper<T> {
         return rtn;
     }
 
+    T deserialize(istream& is, ios::pos_type start, ios::pos_type end) {
+        T rtn;
+        is.seekg(start);
+        auto currPos = start;
+        while (currPos < end) {
+            rtn.insert(
+                rtn.end(),
+                SerializationWrapper<container_value_type>().deserialize(is));
+            currPos = is.tellg();
+        }
+        log::debug("Successfully deserialized entries in pos range [", start,
+                   ", ", end, "): ", rtn);
+        return rtn;
+    }
+
     // TODO: @mli: Add deserialize several entries to a container.
 
     T m_t{};

--- a/utils/sstable.cpp
+++ b/utils/sstable.cpp
@@ -7,8 +7,6 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
-// TODO: @mli: remove thread when we remove sleep.
-#include <thread>
 
 #include "db_config.h"
 #include "log.h"
@@ -32,8 +30,9 @@ SSTable::SSTable(shared_ptr<value_type> table) : Table(), m_metaData() {
 }
 
 SSTableIndex SSTable::flushToDisk() const {
-    SSTableIndex rtn;
-    auto fs = getFileStream(genSSTableFileName(), ios::out);
+    auto ssTableFileName = genSSTableFileName();
+    SSTableIndex rtn(ssTableFileName);
+    auto fs = getFileStream(ssTableFileName, ios::out);
     SerializationWrapper<decltype(m_metaData)>(m_metaData).serialize(fs);
     SerializationWrapper<value_type>(*m_table).serialize(
         fs, [&](value_type::value_type& entry, ios::pos_type pos,
@@ -45,8 +44,8 @@ SSTableIndex SSTable::flushToDisk() const {
             rtn.addIndex(entry.first, pos);
             return true;
         });
-    // TODO: @mli: Remove this sleep.
-    this_thread::sleep_for(chrono::seconds(5));
+    rtn.setEofPos(fs.tellp());
+    //    this_thread::sleep_for(chrono::seconds(5));
     return rtn;
 }
 
@@ -61,9 +60,6 @@ SSTableIndex SSTable::flushToDisk() const {
  */
 void SSTable::loadFromDisk(string_view ssTableFileName,
                            SSTableIndex* ssTableIndex) {
-    // TODO: @mli: Add code to read from file, deserialize, and populate
-    // m_table. If ssTableIndex is not null, also populate the index. This is
-    // needed when we load SSTable back from disk to recover from a crash.
     auto fs = getFileStream(ssTableFileName, ios::in);
     m_metaData = SerializationWrapper<decltype(m_metaData)>().deserialize(fs);
     m_table =
@@ -81,6 +77,9 @@ void SSTable::loadFromDisk(string_view ssTableFileName,
                 ssTableIndex->addIndex(entry.first, pos);
                 return true;
             }));
+    if (ssTableIndex) {
+        ssTableIndex->setEofPos(fs.tellg());
+    }
     log::debug("Successfully deserialzed SSTable: ", *this);
 }
 

--- a/utils/sstable_index.cpp
+++ b/utils/sstable_index.cpp
@@ -4,16 +4,84 @@
 
 #include "sstable_index.h"
 
+#include <filesystem>
+
 #include "log.h"
+#include "serializer.h"
+#include "system_utils.h"
 
 namespace projectdb {
+
+SSTableIndex::SSTableIndex(string ssTableFileName)
+    : m_ssTableFileName(move(ssTableFileName)) {}
 
 void SSTableIndex::addIndex(Table::key_type key, ios::pos_type pos) {
     m_index[move(key)] = pos;
 }
 
+void SSTableIndex::setEofPos(ios::pos_type eofPos) { m_eofPos = eofPos; }
+
+optional<Table::mapped_type> SSTableIndex::seek(
+    const Table::key_type& key) const {
+    auto potentialBlockPos = getPotentialBlockPos(key);
+    if (!potentialBlockPos.has_value()) {
+        return {};
+    }
+    // Load the block from file.
+    auto fs = getFileStream(m_ssTableFileName, ios::in);
+    Table::value_type partialSSTable =
+        SerializationWrapper<Table::value_type>().deserialize(
+            fs, potentialBlockPos.value().first,
+            potentialBlockPos.value().second);
+    const auto cit = partialSSTable.find(key);
+    if (cit == partialSSTable.end()) {
+        return {};
+    }
+    return cit->second;
+}
+
+optional<pair<ios::pos_type, ios::pos_type>> SSTableIndex::getPotentialBlockPos(
+    const Table::key_type& key) const {
+    if (m_index.empty()) {
+        log::error("Index is empty while trying to seek key: ", key);
+        return {};
+    }
+    for (auto cit = m_index.cbegin(); cit != m_index.cend(); cit++) {
+        if (key == cit->first) {
+            ios::pos_type endPos;
+            // This handles the case where the key we seek IS the last key in
+            // the SSTable.
+            if (cit == prev(m_index.cend())) {
+                endPos = m_eofPos;
+            } else {
+                endPos = next(cit)->second;
+            }
+            log::debug("key: ", key, " is found in index at pos: ", cit->second,
+                       ". Will load block: [", cit->second, ", ", endPos, ").");
+            return make_pair(cit->second, endPos);
+        }
+        if (less<Table::key_type>()(key, cit->first)) {
+            if (cit == m_index.cbegin()) {
+                log::debug("key: ", key,
+                           " is less than the first element of the index: ",
+                           cit->first);
+                return {};
+            }
+            log::debug("key: ", key, " is less than index: ", cit->first,
+                       " at pos: ", cit->second, ". Will load block: [",
+                       prev(cit)->second, ", ", cit->second, ").");
+            return make_pair(prev(cit)->second, cit->second);
+        }
+    }
+    // TODO: @mli: SSTableIndex should keep track of the file name that's
+    // generated.
+    log::debug("Key: ", key, " not found in SSTable: ", m_ssTableFileName);
+    return {};
+}
+
 ostream& operator<<(ostream& os, const SSTableIndex& ssTableIndex) {
-    os << "{ m_index: [ " << ssTableIndex.m_index << " ]}";
+    os << "{ m_index: [ " << ssTableIndex.m_index << " ], m_eofPos: ["
+       << ssTableIndex.m_eofPos << "]}";
     return os;
 }
 

--- a/utils/sstable_index.h
+++ b/utils/sstable_index.h
@@ -7,6 +7,9 @@
 
 #include <iostream>
 #include <map>
+#include <optional>
+#include <string>
+#include <utility>
 
 #include "table.h"
 
@@ -16,12 +19,27 @@ namespace projectdb {
 
 class SSTableIndex {
    public:
+    SSTableIndex(string ssTableFileName);
     void addIndex(Table::key_type key, ios::pos_type pos);
+    void setEofPos(ios::pos_type eofPos);
+
+    optional<Table::mapped_type> seek(const Table::key_type& key) const;
 
     friend ostream& operator<<(ostream& os, const SSTableIndex& ssTableIndex);
 
    private:
+    string m_ssTableFileName;
+    /**
+     * key: key_type
+     * value: the start position of the entry with the key.
+     * With the current implementation, the first and the last entry will ALWAYS
+     * be in the index.
+     */
     map<Table::key_type, ios::pos_type> m_index;
+    ios::pos_type m_eofPos;
+
+    optional<pair<ios::pos_type, ios::pos_type>> getPotentialBlockPos(
+        const Table::key_type& key) const;
 };
 
 ostream& operator<<(ostream& os, const SSTableIndex& ssTableIndex);


### PR DESCRIPTION
- Add utility to deserialize the whole SSTable file with SSTableIndex built during the process.
- Add utility to deserialize a section of SSTable file into a container.
- Basically finish SSTableIndex class.